### PR TITLE
Make the MCP server at /mcp discoverable

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,6 +37,7 @@
             "assets": [
               "projects/budgetkey/src/favicon.ico",
               "projects/budgetkey/src/robots.txt",
+              "projects/budgetkey/src/sitemap-mcp.xml",
               "projects/budgetkey/src/assets",
               "projects/budgetkey/src/.well-known"
             ],

--- a/projects/budgetkey/src/app/about/about-page/about-page.component.less
+++ b/projects/budgetkey/src/app/about/about-page/about-page.component.less
@@ -19,6 +19,7 @@ div.md { max-width: 770px; width: 100%; }
             p { color: #3C4948;	font-family: "Abraham TRIAL";	font-size: 20px;	line-height: 26px; }
             li { color: #3C4948;	font-family: "Abraham TRIAL";	font-size: 20px;	line-height: 26px; }
             a { text-decoration: underline; }
+            pre > code { direction: ltr; display: block;}
         }
 }   
 

--- a/projects/budgetkey/src/app/about/about-page/about-page.component.ts
+++ b/projects/budgetkey/src/app/about/about-page/about-page.component.ts
@@ -62,6 +62,9 @@ export class AboutPageComponent {
         if (data['a11y']) {
           return this.http.get(ps.BASE + `/assets/about/a11y.md`, {responseType: 'text'})
         }
+        if (data['mcp']) {
+          return this.http.get(ps.BASE + `/assets/about/mcp.md`, {responseType: 'text'})
+        }
         return this.http.get(ps.BASE + `/assets/about/${this.globalSettings.themeId}.md`, {responseType: 'text'})
       })
     ).subscribe((text: string) => {

--- a/projects/budgetkey/src/app/about/about-routing.module.ts
+++ b/projects/budgetkey/src/app/about/about-routing.module.ts
@@ -4,6 +4,7 @@ import { AboutPageComponent } from './about-page/about-page.component';
 
 const routes: Routes = [
   { path: 'a11y', component: AboutPageComponent, data: {a11y: true}},
+  { path: 'mcp', component: AboutPageComponent, data: {mcp: true}},
   { path: '', component: AboutPageComponent },
 ];
 

--- a/projects/budgetkey/src/app/common-components/theme.budgetkey.he.ts
+++ b/projects/budgetkey/src/app/common-components/theme.budgetkey.he.ts
@@ -520,6 +520,10 @@ export const DEFAULT_THEME: any={
       "title": "מי אנחנו"
     },
     {
+      "href": "/about/mcp",
+      "title": "התחברו בעזרת AI"
+    },
+    {
       "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
       "title": "תרמו לנו"
     }

--- a/projects/budgetkey/src/assets/about/mcp.md
+++ b/projects/budgetkey/src/assets/about/mcp.md
@@ -1,0 +1,73 @@
+# התחברו בעזרת AI — שרת MCP של מפתח התקציב
+
+מפתח התקציב חושף שרת **MCP** (Model Context Protocol) ציבורי, פתוח וללא צורך באימות, שמאפשר לעוזרי AI כמו Claude, ChatGPT ו-Cursor לחפש ולנתח ישירות את נתוני תקציב המדינה.
+
+## כתובת השרת
+
+```
+https://next.obudget.org/mcp
+```
+
+תעבורה: `streamable-http` (HTTP עם הזרמה דו-כיוונית). פרוטוקול MCP גרסה `2025-06-18`.
+
+## מה אפשר לעשות עם זה?
+
+באמצעות השרת, עוזר ה-AI שלכם יכול לגשת ישירות למאגרי המידע של מפתח התקציב, ובכלל זה:
+
+- **ספר התקציב** — סעיפי הוצאות והכנסות מתוכננים ובוצעים, משנת 1997 ועד היום.
+- **תמיכות תקציביות** — תוכניות תמיכה ותשלומים בפועל.
+- **התקשרויות רכש** — חוזים והתקשרויות של הממשלה.
+- **מכרזים וקולות קוראים** — מכרזים, פטורים ממכרז, קולות קוראים.
+- **ארגונים** — חברות, עמותות, רשויות מקומיות וגופים נוספים.
+- **שינויים תקציביים** — בקשות העברה ופירוט תנועות.
+
+## איך להתחבר?
+
+### Claude Desktop / Claude.ai
+
+הוסיפו לרשימת שרתי ה-MCP הרחוקים בהגדרות Claude:
+
+```json
+{
+  "mcpServers": {
+    "budgetkey": {
+      "url": "https://next.obudget.org/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+### ChatGPT (Developer Mode / Apps SDK)
+
+הוסיפו את `https://next.obudget.org/mcp` כשרת MCP חיצוני בהגדרות. אין צורך באימות.
+
+### Cursor / VS Code
+
+ב-`mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "budgetkey": {
+      "url": "https://next.obudget.org/mcp"
+    }
+  }
+}
+```
+
+## גילוי אוטומטי (Discovery)
+
+השרת מפרסם את עצמו בכמה אופנים סטנדרטיים כך שלקוחות חכמים יוכלו לזהות אותו אוטומטית:
+
+- `https://next.obudget.org/.well-known/mcp` — מניפסט לפי SEP-1960
+- `https://next.obudget.org/.well-known/mcp/server-card.json` — Server Card לפי SEP-1649
+- `https://next.obudget.org/.well-known/mcp-server` — לפי IETF draft-serra-mcp-discovery-uri
+
+## קוד פתוח
+
+הקוד של מפתח התקציב ושל השרת זמין בגיטהאב:
+
+- [github.com/OpenBudget/BudgetKey](https://github.com/OpenBudget/BudgetKey)
+
+תקלות, בקשות והצעות? [פתחו issue](https://github.com/OpenBudget/BudgetKey/issues/new).

--- a/projects/budgetkey/src/assets/themes/theme.budgetkey.am.json
+++ b/projects/budgetkey/src/assets/themes/theme.budgetkey.am.json
@@ -52,6 +52,10 @@
         "title": "מי אנחנו"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "תרמו לנו"
       }

--- a/projects/budgetkey/src/assets/themes/theme.budgetkey.ar.json
+++ b/projects/budgetkey/src/assets/themes/theme.budgetkey.ar.json
@@ -52,6 +52,10 @@
         "title": "من نحن"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "تبرّعوا لنا"
       }

--- a/projects/budgetkey/src/assets/themes/theme.budgetkey.en.json
+++ b/projects/budgetkey/src/assets/themes/theme.budgetkey.en.json
@@ -52,6 +52,10 @@
         "title": "About Us"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "Donate"
       }

--- a/projects/budgetkey/src/assets/themes/theme.budgetkey.he.json
+++ b/projects/budgetkey/src/assets/themes/theme.budgetkey.he.json
@@ -52,6 +52,10 @@
         "title": "מי אנחנו"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "תרמו לנו"
       }

--- a/projects/budgetkey/src/assets/themes/theme.budgetkey.ru.json
+++ b/projects/budgetkey/src/assets/themes/theme.budgetkey.ru.json
@@ -52,6 +52,10 @@
         "title": "מי אנחנו"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "תרמו לנו"
       }

--- a/projects/budgetkey/src/index.html
+++ b/projects/budgetkey/src/index.html
@@ -11,6 +11,9 @@
 
   <link rel="icon" type="image/x-icon" href="favicon.ico"/>
   <link rel="search" type="application/opensearchdescription+xml" title="מפתח התקציב" href="https://next.obudget.org/assets/opensearch.xml"/>
+  <link rel="service" type="application/mcp" href="https://next.obudget.org/mcp" title="Israel State Budget MCP Server"/>
+  <link rel="alternate" type="application/json" href="https://next.obudget.org/.well-known/mcp" title="MCP Server Manifest"/>
+  <meta name="mcp-server" content="https://next.obudget.org/mcp"/>
 
   <meta name="author" content="הסדנא לידע ציבורי"/>
   <meta name="description" content="אספנו והנגשנו ב״מפתח התקציב״ את כל המידע על תקציב המדינה ועל הוצאות הממשלה – כדי שנוכל לדעת מה עושים עם הכסף שלנו…"/>

--- a/projects/budgetkey/src/robots.txt
+++ b/projects/budgetkey/src/robots.txt
@@ -1,4 +1,7 @@
 Sitemap: https://next.obudget.org/datapackages/sitemaps/sitemap.xml
+Sitemap: https://next.obudget.org/sitemap-mcp.xml
 
 User-agent: *
 Disallow: /api/
+Allow: /mcp
+Allow: /.well-known/

--- a/projects/budgetkey/src/server.ts
+++ b/projects/budgetkey/src/server.ts
@@ -13,17 +13,82 @@ const indexHtml = join(serverDistFolder, 'index.server.html');
 const app = express();
 const commonEngine = new CommonEngine();
 
-/**
- * Example Express Rest API endpoints can be defined here.
- * Uncomment and define endpoints as necessary.
- *
- * Example:
- * ```ts
- * app.get('/api/**', (req, res) => {
- *   // Handle API request
- * });
- * ```
- */
+const MCP_ENDPOINT = 'https://next.obudget.org/mcp';
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+const MCP_MANIFEST = {
+  mcp_version: MCP_PROTOCOL_VERSION,
+  server_name: 'מפתח התקציב — Israel State Budget MCP',
+  server_version: '1.0.0',
+  endpoints: {
+    streamable_http: MCP_ENDPOINT,
+  },
+  capabilities: {
+    tools: true,
+    resources: false,
+    prompts: false,
+  },
+  authentication: {
+    required: false,
+  },
+  documentation: 'https://next.obudget.org/about/mcp',
+};
+
+const MCP_SERVER_CARD = {
+  $schema: 'https://modelcontextprotocol.io/schemas/server-card/v1.0',
+  version: '1.0',
+  protocolVersion: MCP_PROTOCOL_VERSION,
+  serverInfo: {
+    name: 'מפתח התקציב — Israel State Budget MCP',
+    version: '1.0.0',
+    description: 'Query the Israeli State Budget: budget items, supports, contracts, tenders, entities, revenues, and budgetary changes (1997–present).',
+    homepage: 'https://next.obudget.org/',
+  },
+  transport: {
+    type: 'streamable-http',
+    url: MCP_ENDPOINT,
+  },
+  capabilities: {
+    tools: true,
+    resources: false,
+    prompts: false,
+  },
+};
+
+const MCP_SERVER_IETF = {
+  mcp_version: MCP_PROTOCOL_VERSION,
+  name: 'מפתח התקציב — Israel State Budget MCP',
+  endpoint: MCP_ENDPOINT,
+  transport: 'http',
+  description: 'Israeli state budget data: budget book, support programs, contracts, tenders, entities, revenues, transfers.',
+  capabilities: ['tools'],
+  auth: { type: 'none' },
+  trust_class: 'public',
+};
+
+function sendMcpDiscoveryJson(res: express.Response, body: unknown) {
+  res.set({
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'public, max-age=3600',
+    'X-Content-Type-Options': 'nosniff',
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.send(JSON.stringify(body, null, 2));
+}
+
+app.options(['/.well-known/mcp', '/.well-known/mcp/server-card.json', '/.well-known/mcp-server'], (_req, res) => {
+  res.set({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, Mcp-Session-Id',
+    'Cache-Control': 'public, max-age=3600',
+  });
+  res.sendStatus(204);
+});
+
+app.get('/.well-known/mcp', (_req, res) => sendMcpDiscoveryJson(res, MCP_MANIFEST));
+app.get('/.well-known/mcp/server-card.json', (_req, res) => sendMcpDiscoveryJson(res, MCP_SERVER_CARD));
+app.get('/.well-known/mcp-server', (_req, res) => sendMcpDiscoveryJson(res, MCP_SERVER_IETF));
 
 /**
  * Serve static files from /browser

--- a/projects/budgetkey/src/sitemap-mcp.xml
+++ b/projects/budgetkey/src/sitemap-mcp.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://next.obudget.org/about/mcp</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://next.obudget.org/.well-known/mcp</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+</urlset>

--- a/themes/theme.budgetkey.he.json
+++ b/themes/theme.budgetkey.he.json
@@ -526,6 +526,10 @@
         "title": "מי אנחנו"
       },
       {
+        "href": "/about/mcp",
+        "title": "התחברו בעזרת AI"
+      },
+      {
         "href": "https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal",
         "title": "תרמו לנו"
       }


### PR DESCRIPTION
## Summary

The MCP server at `https://next.obudget.org/mcp` has been running but was completely invisible — no `.well-known/` metadata, no robots/sitemap entry, no HTML hints, no UI affordance. This PR adds discovery in three layers:

**Machine discovery — Express route handlers in `server.ts`**
- `GET /.well-known/mcp` — SEP-1960 manifest
- `GET /.well-known/mcp/server-card.json` — SEP-1649 server card
- `GET /.well-known/mcp-server` — IETF `draft-serra-mcp-discovery-uri-04`
- `OPTIONS` preflight on all three (CORS)
- All return `Content-Type: application/json`, `Cache-Control: public, max-age=3600`, `X-Content-Type-Options: nosniff`, `Access-Control-Allow-Origin: *`

Three competing in-flight specs cover this space and none has shipped; clients probe different paths, so publishing all three is the cheap, safe move.

**HTML / SEO**
- `<link rel="service" type="application/mcp">`, `<link rel="alternate" type="application/json">`, `<meta name="mcp-server">` in `index.html`
- `robots.txt`: explicit `Allow: /mcp`, `Allow: /.well-known/`, second `Sitemap:` entry
- New `sitemap-mcp.xml` listing `/about/mcp` and `/.well-known/mcp`

**Human**
- New `/about/mcp` route — reuses `AboutPageComponent` with a new data flag, renders `assets/about/mcp.md` (Hebrew docs with config snippets for Claude / ChatGPT / Cursor)
- New `התחברו בעזרת AI` header link via `theme.budgetkey.he.ts`

## Out of scope (follow-up ops)

- DNS TXT: `_mcp.next.obudget.org IN TXT "v=mcp1; src=https://next.obudget.org/mcp; auth=none"` — needs DNS zone access
- Submission to the official MCP Registry under `org.obudget/budgetkey` (DNS-verified)

## Test plan

Local SSR build + curl, all checks pass:

- [x] `npm run build` succeeds (only pre-existing warnings)
- [x] `curl -sI /.well-known/mcp` → 200 + JSON + cache + nosniff + CORS
- [x] `curl -sI /.well-known/mcp/server-card.json` → same
- [x] `curl -sI /.well-known/mcp-server` → same
- [x] `curl -sI -X OPTIONS /.well-known/mcp` → 204 + CORS preflight headers
- [x] `curl /robots.txt` shows both `Sitemap:` lines and the new `Allow:` rules
- [x] `curl /sitemap-mcp.xml` returns valid XML
- [x] `curl /` HTML contains all three MCP hint tags
- [x] `curl /about/mcp` renders the SSR shell; `/assets/about/mcp.md` serves with `text/markdown`
- [x] Verified header link is bundled into `chunk-C3ZEMDI7.js`

After deploy, also verify in a real client:
- [ ] Add `https://next.obudget.org/mcp` to Claude Desktop as a remote MCP server — confirm tools are listed
- [ ] Browse to `/about/mcp` in a browser — confirm header link visible and docs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)