### PR TITLE
Add social procurement measurement tab (מדידת הרכש החברתי)

### DIFF
--- a/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.html
+++ b/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.html
@@ -76,22 +76,22 @@
     </div>        
 
 
-    <div class='well filters-wrapper' #filtersElement>
+    <div class='well filters-wrapper' [class.measurement-mode]='currentTab === "measurement"' #filtersElement>
         <div class='filters'>
             <div class='filter' *ngFor='let filter of PAGE_FILTERS'>
                 <label [for]='filter.id' *ngIf='!filter.tooltip'>{{ filter.title }}</label>
                 <label [for]='filter.id' *ngIf='filter.tooltip' class='bk-tooltip-anchor'>{{ filter.title }}<span class='bk-tooltip'>{{ filter.tooltip }}</span></label>
                 <app-multi-select [title]='filter.title' [(value)]='filters[filter.id]' [id]='filter.id' [options]='parameters[filter.id]'></app-multi-select>
             </div>
-            <div class='filter' *ngIf='subunits'>
-                <label>מנהל/אגף</label>
+            <div class='filter unit-filter' *ngIf='subunits'>
+                <label>מינהל</label>
                 <select [(ngModel)]='item.unit' (change)='processLevel()'>
                     <option value='' selected>הכל</option>
                     <option *ngFor='let option of subunits' [value]='option'>{{option}}</option>
                 </select>
             </div>
         </div>
-        <div class='subtext'>
+        <div class='subtext' [class.hidden]='currentTab === "measurement"'>
             <span>לסימון מספר אפשרויות יש להשתמש בכפתורי Shift/Ctrl/Cmd במקלדת</span>
             <a class='clear-filters' (activated)='clearFilters()' clickOnReturn>ניקוי כל הסינונים</a>
             <button type='button' class='apply-filters' (activated)='filtersChanged()' clickOnReturn>סינון</button>
@@ -109,7 +109,10 @@
     >הרחבה לגבי מפעילי השירותים</a>
     <a [class.active]='currentTab === "tenders"' (activated)='setCurrentTab("tenders")' tabindex='0' clickOnReturn
         role='tab' [attr.aria-selected]='currentTab === "tenders"' aria-controls='tab-panel'
-    >הרחבה על הליכי רכש (בהרצה)</a>
+    >הרחבה על הליכי רכש</a>
+    <a [class.active]='currentTab === "measurement"' (activated)='setCurrentTab("measurement")' tabindex='0' clickOnReturn
+        role='tab' [attr.aria-selected]='currentTab === "measurement"' aria-controls='tab-panel'
+    >מדידת הרכש החברתי</a>
 </div>
 
 <div class='charts columns-2' #chartsSection id='tab-panel'>
@@ -128,7 +131,83 @@
     </ng-container>    
 </div>
 
-<ng-container *ngIf='ps.browser()'>
+<ng-container *ngIf='ps.browser() && currentTab !== "measurement"'>
     <app-social-service-data-table *ngIf='colorscheme | async' [tables]='tables' [default]='"services"' [replacements]='replacements' [filename]='item.page_title' [item]='item'></app-social-service-data-table>
 </ng-container>
+
+<div class='measurement-section' *ngIf='currentTab === "measurement"'>
+    <div class='measurement-intro'>
+        <p>
+            בהמשך <a href='https://www.gov.il/he/pages/dec489_2020' target='_blank'>להחלטת ממשלה מספר 489</a>, אגף ממשל וחברה במשרד רה"מ והמשרדים החברתיים מפרסמים את ממצאי המדידה של הרכש החברתי.
+            המדדים מאפשרים לבחון את המידה שבה כל משרד מטמיע את עקרונות הרכש החברתי המיטבי בתהליכי התכנון של השירותים ובמכרזים לרכש שירותים חברתיים.
+            כלי המדידה מיושם על כל מכרז בנפרד והנתונים המצטברים מאפשרים לראות תמונה רוחבית ולהשוות בין מינהלים ומשרדים.
+        </p>
+        <p>
+            ממצאי המדידה מאפשרים לבחון עד כמה המשרדים החברתיים מצליחים בהטמעת המדיניות הממשלתית בתחום הרכש החברתי, אילו עקרונות מדיניות מיושמים פחות או יותר ולזהות נושאים שיש לחזק ולשפר.
+        </p>
+    </div>
+
+    <div class='measurement-no-data' *ngIf='!measurementData || measurementData.total < MEASUREMENT_MIN_TENDERS'>
+        אין די נתונים מדידת הרכש החברתי בסינון הנבחר
+    </div>
+
+    <ng-container *ngIf='measurementData && measurementData.total >= MEASUREMENT_MIN_TENDERS'>
+        <div class='measurement-main-chart'>
+            <h3>ממצאי מדידת הרכש החברתי, {{MEASUREMENT_YEAR}}</h3>
+            <div class='chart-subtitle'>מבוסס על מדידת {{measurementData.total}} מכרזים</div>
+            <div class='measurement-legend'>
+                <span class='legend-label'>מידת יישום עקרונות הרכש החברתי</span>
+                <span class='legend-item legend-high'>במידה רבה</span>
+                <span class='legend-item legend-med'>במידה בינונית</span>
+                <span class='legend-item legend-low'>במידה מועטה</span>
+            </div>
+            <div class='principle-bars'>
+                <div class='principle-bar-row' *ngFor='let p of principleData'>
+                    <div class='stacked-bar'>
+                        <div class='bar-high' [style.width.%]='p.highPct' *ngIf='p.highPct > 0'></div>
+                        <div class='bar-med'  [style.width.%]='p.medPct'  *ngIf='p.medPct > 0'></div>
+                        <div class='bar-low'  [style.width.%]='p.lowPct'  *ngIf='p.lowPct > 0'></div>
+                    </div>
+                    <span class='principle-label'>{{p.name}}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class='measurement-aspects'>
+            <h3>פירוט ההיבטים שנבדקו עבור כל עיקרון</h3>
+            <div class='measurement-legend'>
+                <span class='legend-item legend-high'>במידה רבה</span>
+                <span class='legend-item legend-med'>במידה בינונית</span>
+                <span class='legend-item legend-low'>במידה מועטה</span>
+            </div>
+            <div class='aspects-grid'>
+                <div class='principle-box' *ngFor='let p of principleAspects'>
+                    <h4>{{p.principleTitle}}</h4>
+                    <ng-container *ngFor='let a of p.aspects'>
+                        <div class='aspect-row' [class.aspect-core]='a.isCore'>
+                            <div class='stacked-bar'>
+                                <div class='bar-high' [style.width.%]='a.highPct' *ngIf='a.highPct > 0'>{{a.highPct}}%</div>
+                                <div class='bar-med'  [style.width.%]='a.medPct'  *ngIf='a.medPct > 0'>{{a.medPct}}%</div>
+                                <div class='bar-low'  [style.width.%]='a.lowPct'  *ngIf='a.lowPct > 0'>{{a.lowPct}}%</div>
+                            </div>
+                            <div class='aspect-label-col'>
+                                <div class='core-header' *ngIf='a.isCore'>
+                                    <svg class='core-icon' width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M9.33333 17.6667C13.9357 17.6667 17.6667 13.9357 17.6667 9.33333C17.6667 4.73096 13.9357 1 9.33333 1C4.73096 1 1 4.73096 1 9.33333C1 13.9357 4.73096 17.6667 9.33333 17.6667Z" stroke="#CB30E0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M9.33333 14.3333C12.0948 14.3333 14.3333 12.0948 14.3333 9.33333C14.3333 6.57191 12.0948 4.33333 9.33333 4.33333C6.57191 4.33333 4.33333 6.57191 4.33333 9.33333C4.33333 12.0948 6.57191 14.3333 9.33333 14.3333Z" stroke="#CB30E0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M9.33333 11C10.2538 11 11 10.2538 11 9.33333C11 8.41286 10.2538 7.66667 9.33333 7.66667C8.41286 7.66667 7.66667 8.41286 7.66667 9.33333C7.66667 10.2538 8.41286 11 9.33333 11Z" stroke="#CB30E0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                                    <span class='core-label'>היבט ליבה</span>
+                                    <img src='assets/item/img/icon-Info.svg' class='info-icon' alt=''/>
+                                </div>
+                                <div class='aspect-label'>{{a.name}}</div>
+                            </div>
+                        </div>
+                    </ng-container>
+                </div>
+            </div>
+        </div>
+    </ng-container>
+</div>
+
 <div class='sticky-contact-us'><a href='mailto:rehesh.hevrati@pmo.gov.il' target='_blank'>יצירת קשר או דיווח על תקלה</a></div>

--- a/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.less
+++ b/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.less
@@ -165,4 +165,271 @@
         text-underline-offset: 2px;
     }
 
+    .filters-wrapper.measurement-mode {
+        .filter:not(.unit-filter) {
+            pointer-events: none;
+            position: relative;
+            &::after {
+                content: '';
+                position: absolute;
+                inset: -2px;
+                background: rgba(220, 220, 225, 0.72);
+                border-radius: 4px;
+                z-index: 2;
+            }
+        }
+        .subtext.hidden {
+            display: none;
+        }
+    }
+
+    .measurement-section {
+        direction: rtl;
+        padding: 28px 40px 40px;
+        max-width: 1100px;
+        margin: 0 auto;
+
+        .measurement-intro {
+            margin-bottom: 36px;
+            max-width: 820px;
+            text-align: justify;
+            p {
+                font-size: 16px;
+                line-height: 1.8;
+                color: #333;
+                margin-bottom: 14px;
+            }
+            a {
+                color: #038CA4;
+                font-weight: 600;
+                text-decoration: none;
+                &:hover { text-decoration: underline; }
+            }
+        }
+
+        .measurement-no-data {
+            font-size: 16px;
+            color: #666;
+            padding: 32px 0;
+            text-align: center;
+        }
+
+        h3 {
+            font-size: 22px;
+            font-weight: 700;
+            color: #192841;
+            margin-bottom: 4px;
+        }
+
+        .chart-subtitle {
+            font-size: 14px;
+            color: #666;
+            margin-bottom: 12px;
+        }
+
+        .measurement-legend {
+            display: flex;
+            flex-flow: row;
+            gap: 10px;
+            margin-bottom: 28px;
+            align-items: center;
+
+            .legend-label {
+                font-size: 14px;
+                color: #555;
+                margin-left: 6px;
+            }
+
+            .legend-item {
+                display: inline-block;
+                font-size: 13px;
+                font-weight: 600;
+                padding: 4px 12px;
+                border-radius: 20px;
+                white-space: nowrap;
+            }
+            .legend-high {
+                background: #d4ede6;
+                color: #1b6352;
+                border: 1px solid #90ccbc;
+            }
+            .legend-med {
+                background: #5ab8d0;
+                color: #fff;
+            }
+            .legend-low {
+                background: #1e6d78;
+                color: #fff;
+            }
+        }
+
+        .measurement-main-chart {
+            margin-bottom: 48px;
+            background: #fff;
+            border-radius: 10px;
+            padding: 32px 40px 36px;
+            box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+
+            h3 {
+                text-align: center;
+                font-size: 26px;
+                font-weight: 700;
+                margin-bottom: 6px;
+            }
+
+            .chart-subtitle {
+                text-align: center;
+                font-size: 15px;
+                margin-bottom: 28px;
+            }
+
+            .principle-bars {
+                display: flex;
+                flex-flow: column;
+                gap: 22px;
+                margin-top: 8px;
+            }
+
+            .principle-bar-row {
+                display: flex;
+                flex-flow: row;
+                align-items: center;
+                gap: 20px;
+
+                .principle-label {
+                    flex: 1 1 0;
+                    font-size: 16px;
+                    font-weight: 400;
+                    color: #2c2c2c;
+                    text-align: right;
+                    line-height: 1.4;
+                }
+            }
+        }
+
+        .stacked-bar {
+            flex: 1 1 0;
+            display: flex;
+            flex-flow: row;
+            height: 42px;
+            border-radius: 6px;
+            overflow: hidden;
+
+            > div {
+                transition: width 400ms ease;
+            }
+
+            .bar-high { background: #93d0bc; }
+            .bar-med  { background: #5ab8d0; }
+            .bar-low  { background: #1e6d78; }
+        }
+
+        .measurement-aspects {
+            h3 {
+                text-align: center;
+                margin-bottom: 12px;
+            }
+
+            .measurement-legend {
+                justify-content: center;
+            }
+
+            .aspects-grid {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 20px;
+                margin-top: 16px;
+
+                @media (max-width: 800px) {
+                    grid-template-columns: 1fr;
+                }
+            }
+
+            .principle-box {
+                border: 1px solid #dde3ed;
+                border-radius: 10px;
+                padding: 20px 24px;
+                background: #fff;
+                box-shadow: 0 1px 6px rgba(0,0,0,0.07);
+
+                h4 {
+                    font-size: 15px;
+                    font-weight: 700;
+                    margin-bottom: 16px;
+                    color: #192841;
+                    padding-bottom: 10px;
+                    border-bottom: 2px solid #e8ecf2;
+                    text-align: right;
+                }
+
+                .aspect-row {
+                    display: flex;
+                    flex-flow: row;
+                    align-items: center;
+                    gap: 14px;
+                    margin-bottom: 12px;
+
+                    .aspect-label-col {
+                        flex: 1 1 0;
+                        display: flex;
+                        flex-flow: column;
+                        gap: 4px;
+                    }
+
+                    .aspect-label {
+                        font-size: 13px;
+                        color: #333;
+                        line-height: 1.45;
+                        text-align: right;
+                    }
+
+                    .stacked-bar {
+                        flex: 0 0 42%;
+                        height: 30px;
+                        border-radius: 4px;
+                    }
+                }
+
+                .aspect-row.aspect-core {
+                    border-top: 1px solid #e8ecf2;
+                    padding-top: 12px;
+                    margin-top: 14px;
+                    align-items: flex-start;
+                }
+
+                .core-header {
+                    display: flex;
+                    flex-flow: row;
+                    align-items: center;
+                    gap: 6px;
+
+                    .core-icon { width: 18px; height: 18px; flex-shrink: 0; }
+                    .core-label { font-size: 13px; font-weight: 700; color: #546e7a; }
+                    .info-icon { width: 15px; height: 15px; opacity: 0.5; flex-shrink: 0; }
+                }
+
+                .aspect-core { margin-bottom: 0; }
+            }
+
+            .bar-high { background: #9db8c8 !important; }
+            .bar-med  { background: #5d7e94 !important; }
+            .bar-low  { background: #2e4f64 !important; }
+
+            .bar-high { color: rgba(255,255,255,0.85) !important; }
+
+            .legend-high { background: #9db8c8 !important; color: #fff !important; border: none !important; }
+            .legend-med  { background: #5d7e94 !important; color: #fff !important; }
+            .legend-low  { background: #2e4f64 !important; color: #fff !important; }
+        }
+
+        .stacked-bar > div {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 11px;
+            font-weight: 600;
+            color: rgba(255,255,255,0.92);
+        }
+    }
+
 }

--- a/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.ts
+++ b/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.ts
@@ -523,11 +523,9 @@ export class ItemSocialServiceGovUnitComponent implements OnInit, AfterViewInit 
 
   private tierPcts(total: number, low: number, med: number, high: number) {
     if (!total) return {lowPct: 0, medPct: 0, highPct: 0};
-    return {
-      lowPct: Math.round(low / total * 100),
-      medPct: Math.round(med / total * 100),
-      highPct: Math.round(high / total * 100),
-    };
+    const lowPct = Math.round(low / total * 100);
+    const medPct = Math.round(med / total * 100);
+    return {lowPct, medPct, highPct: 100 - lowPct - medPct};
   }
 
   get principleData(): any[] {

--- a/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.ts
+++ b/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/item-social-service-gov-unit.component.ts
@@ -1,4 +1,61 @@
+// measurement tab - purple icon core-header-in-label-col
 import { AfterViewInit, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+
+const MEASUREMENT_QUERY = `SELECT
+  count(*) as total,
+  sum(case when principle_score_1 < 0.35 then 1 else 0 end) as p1_low,
+  sum(case when principle_score_1 >= 0.35 and principle_score_1 < 0.70 then 1 else 0 end) as p1_med,
+  sum(case when principle_score_1 >= 0.70 then 1 else 0 end) as p1_high,
+  sum(case when principle_score_2 < 0.35 then 1 else 0 end) as p2_low,
+  sum(case when principle_score_2 >= 0.35 and principle_score_2 < 0.70 then 1 else 0 end) as p2_med,
+  sum(case when principle_score_2 >= 0.70 then 1 else 0 end) as p2_high,
+  sum(case when principle_score_3 < 0.35 then 1 else 0 end) as p3_low,
+  sum(case when principle_score_3 >= 0.35 and principle_score_3 < 0.70 then 1 else 0 end) as p3_med,
+  sum(case when principle_score_3 >= 0.70 then 1 else 0 end) as p3_high,
+  sum(case when principle_score_4 < 0.35 then 1 else 0 end) as p4_low,
+  sum(case when principle_score_4 >= 0.35 and principle_score_4 < 0.70 then 1 else 0 end) as p4_med,
+  sum(case when principle_score_4 >= 0.70 then 1 else 0 end) as p4_high,
+  sum(case when principle_score_5 < 0.35 then 1 else 0 end) as p5_low,
+  sum(case when principle_score_5 >= 0.35 and principle_score_5 < 0.70 then 1 else 0 end) as p5_med,
+  sum(case when principle_score_5 >= 0.70 then 1 else 0 end) as p5_high,
+  sum(case when principle_score_6 < 0.35 then 1 else 0 end) as p6_low,
+  sum(case when principle_score_6 >= 0.35 and principle_score_6 < 0.70 then 1 else 0 end) as p6_med,
+  sum(case when principle_score_6 >= 0.70 then 1 else 0 end) as p6_high,
+  sum(case when principle_score_1_1 < 0.35 then 1 else 0 end) as p1_1_low,
+  sum(case when principle_score_1_1 >= 0.35 and principle_score_1_1 < 0.70 then 1 else 0 end) as p1_1_med,
+  sum(case when principle_score_1_1 >= 0.70 then 1 else 0 end) as p1_1_high,
+  sum(case when principle_score_1_2 < 0.35 then 1 else 0 end) as p1_2_low,
+  sum(case when principle_score_1_2 >= 0.35 and principle_score_1_2 < 0.70 then 1 else 0 end) as p1_2_med,
+  sum(case when principle_score_1_2 >= 0.70 then 1 else 0 end) as p1_2_high,
+  sum(case when principle_score_1_3 < 0.35 then 1 else 0 end) as p1_3_low,
+  sum(case when principle_score_1_3 >= 0.35 and principle_score_1_3 < 0.70 then 1 else 0 end) as p1_3_med,
+  sum(case when principle_score_1_3 >= 0.70 then 1 else 0 end) as p1_3_high,
+  sum(case when principle_score_1_4 < 0.35 then 1 else 0 end) as p1_4_low,
+  sum(case when principle_score_1_4 >= 0.35 and principle_score_1_4 < 0.70 then 1 else 0 end) as p1_4_med,
+  sum(case when principle_score_1_4 >= 0.70 then 1 else 0 end) as p1_4_high,
+  sum(case when principle_score_2_1 < 0.35 then 1 else 0 end) as p2_1_low,
+  sum(case when principle_score_2_1 >= 0.35 and principle_score_2_1 < 0.70 then 1 else 0 end) as p2_1_med,
+  sum(case when principle_score_2_1 >= 0.70 then 1 else 0 end) as p2_1_high,
+  sum(case when principle_score_2_2 < 0.35 then 1 else 0 end) as p2_2_low,
+  sum(case when principle_score_2_2 >= 0.35 and principle_score_2_2 < 0.70 then 1 else 0 end) as p2_2_med,
+  sum(case when principle_score_2_2 >= 0.70 then 1 else 0 end) as p2_2_high,
+  sum(case when principle_score_3_1 < 0.35 then 1 else 0 end) as p3_1_low,
+  sum(case when principle_score_3_1 >= 0.35 and principle_score_3_1 < 0.70 then 1 else 0 end) as p3_1_med,
+  sum(case when principle_score_3_1 >= 0.70 then 1 else 0 end) as p3_1_high,
+  sum(case when principle_score_3_2 < 0.35 then 1 else 0 end) as p3_2_low,
+  sum(case when principle_score_3_2 >= 0.35 and principle_score_3_2 < 0.70 then 1 else 0 end) as p3_2_med,
+  sum(case when principle_score_3_2 >= 0.70 then 1 else 0 end) as p3_2_high,
+  sum(case when principle_score_6_1 < 0.35 then 1 else 0 end) as p6_1_low,
+  sum(case when principle_score_6_1 >= 0.35 and principle_score_6_1 < 0.70 then 1 else 0 end) as p6_1_med,
+  sum(case when principle_score_6_1 >= 0.70 then 1 else 0 end) as p6_1_high,
+  sum(case when principle_score_6_2 < 0.35 then 1 else 0 end) as p6_2_low,
+  sum(case when principle_score_6_2 >= 0.35 and principle_score_6_2 < 0.70 then 1 else 0 end) as p6_2_med,
+  sum(case when principle_score_6_2 >= 0.70 then 1 else 0 end) as p6_2_high,
+  sum(case when principle_score_6_3 < 0.35 then 1 else 0 end) as p6_3_low,
+  sum(case when principle_score_6_3 >= 0.35 and principle_score_6_3 < 0.70 then 1 else 0 end) as p6_3_med,
+  sum(case when principle_score_6_3 >= 0.70 then 1 else 0 end) as p6_3_high
+FROM soproc_measurement
+WHERE :where`;
 import { Subscription, ReplaySubject, from, mergeMap, map, first, switchMap, delay, fromEvent, throttleTime, forkJoin, interval, animationFrameScheduler } from 'rxjs';
 import { BudgetKeyItemService } from '../../../budgetkey-item.service';
 import { tableDefs } from './tables';
@@ -53,6 +110,10 @@ export class ItemSocialServiceGovUnitComponent implements OnInit, AfterViewInit 
     '#E4CF43', // 11
   ];
   OTHER_COLOR_IDX = this.COLORS.length - 1;
+
+  readonly MEASUREMENT_YEAR = '2025';
+  readonly MEASUREMENT_MIN_TENDERS = 3;
+  public measurementData: any = null;
 
   public parameters: any = {
     pricing_model: [
@@ -306,6 +367,7 @@ export class ItemSocialServiceGovUnitComponent implements OnInit, AfterViewInit 
       {from: ':tender-type', to: this.filterExpression('tender_type')},
       {from: ':pricing-model', to: this.filterExpression('pricing_model')},
     ];
+    this.fetchMeasurementData();
   }
 
   clearFilters() {
@@ -437,6 +499,104 @@ export class ItemSocialServiceGovUnitComponent implements OnInit, AfterViewInit 
     } else {
       return ct.title;
     }
+  }
+
+  calcMeasurementWhere(): string {
+    return this.levelCond;
+  }
+
+  private encodeQuery(query: string): string {
+    return btoa(encodeURIComponent(query).replace(/%([0-9A-F]{2})/g, (_m, p1) => String.fromCharCode(parseInt(p1, 16))));
+  }
+
+  fetchMeasurementData() {
+    if (this.ps.server()) return;
+    const where = this.calcMeasurementWhere();
+    const query = MEASUREMENT_QUERY.split(':where').join(where);
+    const encoded = this.encodeQuery(query);
+    this.api.getItemData(encoded, ['total'], [this.formatter('total')])
+      .subscribe((result: any) => {
+        const rows = result.rows || [];
+        this.measurementData = rows.length > 0 ? rows[0] : null;
+      });
+  }
+
+  private tierPcts(total: number, low: number, med: number, high: number) {
+    if (!total) return {lowPct: 0, medPct: 0, highPct: 0};
+    return {
+      lowPct: Math.round(low / total * 100),
+      medPct: Math.round(med / total * 100),
+      highPct: Math.round(high / total * 100),
+    };
+  }
+
+  get principleData(): any[] {
+    if (!this.measurementData) return [];
+    const d = this.measurementData;
+    const t = +d.total;
+    return [
+      {name: 'עקרון ראשון: מקבל השירות במרכז',                        ...this.tierPcts(t, +d.p1_low, +d.p1_med, +d.p1_high)},
+      {name: 'עקרון שני: ניהול מוכוון תוצאות',                        ...this.tierPcts(t, +d.p2_low, +d.p2_med, +d.p2_high)},
+      {name: 'עקרון שלישי: חדשנות וגמישות',                           ...this.tierPcts(t, +d.p3_low, +d.p3_med, +d.p3_high)},
+      {name: 'עקרון רביעי: פיתוח ושימור ידע',                         ...this.tierPcts(t, +d.p4_low, +d.p4_med, +d.p4_high)},
+      {name: 'עקרון חמישי: המפעיל כשותף',                             ...this.tierPcts(t, +d.p5_low, +d.p5_med, +d.p5_high)},
+      {name: 'עקרון שישי: תכנון כלכלי ותחרות בשירות האיכות',          ...this.tierPcts(t, +d.p6_low, +d.p6_med, +d.p6_high)},
+    ];
+  }
+
+  get principleAspects(): any[] {
+    if (!this.measurementData) return [];
+    const d = this.measurementData;
+    const t = +d.total;
+    return [
+      {
+        principleTitle: 'עקרון ראשון: מקבל השירות במרכז',
+        aspects: [
+          {name: 'למקבלי השירות יש קול בתהליך עיצוב השירות ולאורך מתן השירותים',                                      isCore: false, ...this.tierPcts(t, +d.p1_2_low, +d.p1_2_med, +d.p1_2_high)},
+          {name: 'המידע על השירות מונגש למקבלי השירות כך שיוכלו למצות את זכויותיהם בשירות',                           isCore: false, ...this.tierPcts(t, +d.p1_3_low, +d.p1_3_med, +d.p1_3_high)},
+          {name: 'נשמרת רציפות ויציבות במתן שירותים או קשר טיפולי',                                                   isCore: false, ...this.tierPcts(t, +d.p1_4_low, +d.p1_4_med, +d.p1_4_high)},
+          {name: 'השירות מותאם לצרכי כלל מקבלי השירות',                                                               isCore: true,  ...this.tierPcts(t, +d.p1_1_low, +d.p1_1_med, +d.p1_1_high)},
+        ]
+      },
+      {
+        principleTitle: 'עקרון שני: ניהול מוכוון תוצאות',
+        aspects: [
+          {name: 'יש לשירות מערך מדידה לבחינת מידת השגת התוצאות ומתבצע ניהול שירות מוכוון תוצאות',                  isCore: false, ...this.tierPcts(t, +d.p2_2_low, +d.p2_2_med, +d.p2_2_high)},
+          {name: 'השירות מוכוון להשגת תוצאות מוגדרות',                                                                isCore: true,  ...this.tierPcts(t, +d.p2_1_low, +d.p2_1_med, +d.p2_1_high)},
+        ]
+      },
+      {
+        principleTitle: 'עקרון שלישי: חדשנות וגמישות',
+        aspects: [
+          {name: 'מתאפשרת גמישות בהתאמת השירות לצרכים משתנים',                                                        isCore: false, ...this.tierPcts(t, +d.p3_2_low, +d.p3_2_med, +d.p3_2_high)},
+          {name: 'מודל השירות משקף את חזית הידע',                                                                      isCore: true,  ...this.tierPcts(t, +d.p3_1_low, +d.p3_1_med, +d.p3_1_high)},
+        ]
+      },
+      {
+        principleTitle: 'עקרון רביעי: פיתוח ושימור ידע',
+        aspects: [
+          {name: 'ידע המפותח והנצבר במהלך ההתקשרות מתועד באופן המאפשר שימור, שיתוף ולמידה ומועבר במלואו למשרד ו/או למפעיל מחליף', isCore: true, ...this.tierPcts(t, +d.p4_low, +d.p4_med, +d.p4_high)},
+        ]
+      },
+      {
+        principleTitle: 'עקרון חמישי: המפעיל כשותף',
+        aspects: [
+          {name: 'מתקיים שיח מקצועי רציף בין המשרד למפעילים בשלבי תכנון השירות ובמהלך מתן השירותים',                 isCore: true, ...this.tierPcts(t, +d.p5_low, +d.p5_med, +d.p5_high)},
+        ]
+      },
+      {
+        principleTitle: 'עקרון שישי: תכנון כלכלי ותחרות בשירות האיכות',
+        aspects: [
+          {name: 'הגברת תחרות בין מפעילים במהלך חיי ההתקשרות',                                                        isCore: false, ...this.tierPcts(t, +d.p6_2_low, +d.p6_2_med, +d.p6_2_high)},
+          {name: 'תכנון כלכלי ההולם את הצרכים הנדרשים למתן שירות איכותי',                                             isCore: false, ...this.tierPcts(t, +d.p6_3_low, +d.p6_3_med, +d.p6_3_high)},
+          {name: 'הגברת התחרות בין מתמודדים בתקופת המכרוז',                                                            isCore: true,  ...this.tierPcts(t, +d.p6_1_low, +d.p6_1_med, +d.p6_1_high)},
+        ]
+      },
+    ];
+  }
+
+  getCoreAspect(p: any): any {
+    return p.aspects?.find((a: any) => a.isCore);
   }
 
 }

--- a/projects/budgetkey/src/assets/item/img/core-principle.svg
+++ b/projects/budgetkey/src/assets/item/img/core-principle.svg
@@ -1,0 +1,5 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.33333 17.6667C13.9357 17.6667 17.6667 13.9357 17.6667 9.33333C17.6667 4.73096 13.9357 1 9.33333 1C4.73096 1 1 4.73096 1 9.33333C1 13.9357 4.73096 17.6667 9.33333 17.6667Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.33333 14.3333C12.0948 14.3333 14.3333 12.0948 14.3333 9.33333C14.3333 6.57191 12.0948 4.33333 9.33333 4.33333C6.57191 4.33333 4.33333 6.57191 4.33333 9.33333C4.33333 12.0948 6.57191 14.3333 9.33333 14.3333Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.33333 11C10.2538 11 11 10.2538 11 9.33333C11 8.41286 10.2538 7.66667 9.33333 7.66667C8.41286 7.66667 7.66667 8.41286 7.66667 9.33333C7.66667 10.2538 8.41286 11 9.33333 11Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/projects/budgetkey/src/assets/item/img/icon-Info.svg
+++ b/projects/budgetkey/src/assets/item/img/icon-Info.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2196_914)">
+<path d="M9.99996 13.3332V9.99984M9.99996 6.6665H10.0083M18.3333 9.99984C18.3333 14.6022 14.6023 18.3332 9.99996 18.3332C5.39759 18.3332 1.66663 14.6022 1.66663 9.99984C1.66663 5.39746 5.39759 1.6665 9.99996 1.6665C14.6023 1.6665 18.3333 5.39746 18.3333 9.99984Z" stroke="#B3B3B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_2196_914">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a 4th tab **"מדידת הרכש החברתי"** to the `item-social-service-gov-unit` component
- **Hero chart**: centered white card with box shadow; 6 horizontal stacked bars (one per principle), each split into high/medium/low tiers with percentages inside bars; RTL layout; teal color palette
- **Aspects grid**: 2-column grid of 6 principle boxes; each shows sub-aspect bars in a blue-grey grayscale palette; core aspect (היבט ליבה) is always last in its box, preceded by a purple concentric-circles icon + label aligned with the text column
- **No-data state**: shows a message when fewer than 3 tenders match the filter
- Adds `core-principle.svg` and `icon-Info.svg` assets used by the measurement tab

## Test plan

- [ ] Navigate to \`/i/units/gov_social_service_unit/welfare?theme=soproc\`
- [ ] Click "מדידת הרכש החברתי" tab — intro text, hero chart (6 bars), and aspects grid all appear
- [ ] Hero chart: centered, white background, box shadow, correct teal colors, percentages inside bars
- [ ] Aspects grid: grayscale bars, "היבט ליבה" purple icon + label above core aspect text in each box, core aspect last
- [ ] Filter by ministry — both charts update
- [ ] Content filters are hidden (grayed out) when on measurement tab; unit dropdown remains active

🤖 Generated with [Claude Code](https://claude.com/claude-code)