### PR TITLE
Fix operator precedence in gov-unit suppliers table filter

### DIFF
--- a/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/tables.ts
+++ b/projects/budgetkey/src/app/item/items/item-soproc/item-social-service-gov-unit/tables.ts
@@ -132,7 +132,7 @@ export const tableDefs = {
       SELECT :fields
       FROM e
       WHERE relevant AND
-            (NOT :only-active) OR active`,
+            ((NOT :only-active) OR active)`,
         downloadHeaders: [
             `מספר תאגיד<id`,
             `שם המפעיל<name`,


### PR DESCRIPTION
## Problem

The `מפעילים` table query on the social-service gov-unit page ended with:

```sql
WHERE relevant AND (NOT :only-active) OR active
```

`AND` binds tighter than `OR`, so Postgres parsed this as:

```sql
WHERE (relevant AND NOT :only-active) OR active
```

With the **"הצגת רק שורות פעילות"** checkbox ticked, `:only-active` is `TRUE`, which collapses the first branch to `FALSE` and leaves just `WHERE active`. The `relevant` flag — which carries the office/unit level condition *and* every page filter — is discarded entirely, so the table returns every active operator across all of government.

## Impact

On `/i/units/gov_social_service_unit/welfare` with the checkbox on, the table returned **963 rows instead of 642** — the full cross-government list rather than משרד הרווחה's operators. Same for every sub-unit page and every combination of the page filters. The main page was unaffected, since `relevant` is `TRUE` for every row there.

## Fix

Parenthesise the `:only-active` clause so it can't swallow the `relevant` predicate.

## Verification

Ran the generated SQL against the live API before and after:

| Page | active-only | before | after |
|---|---|---|---|
| main | on | 963 | 963 (unchanged) |
| main | off | 998 | 998 (unchanged) |
| משרד הרווחה | on | 963 ❌ | **642** ✅ |
| משרד הרווחה | off | 661 | 661 (unchanged) |

## Scope

The other three `:only-active` sites (`item-social-service/tables.ts:36,105` and `item-social-service-gov-unit/tables.ts:196`) apply `:where` inside a CTE, so their `WHERE (NOT :only-active) OR active` has no dangling `AND` to mis-bind. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)